### PR TITLE
fixed include paths, made mult inline

### DIFF
--- a/src/SurfingImGui/SurfingGuiManager.h
+++ b/src/SurfingImGui/SurfingGuiManager.h
@@ -41,14 +41,14 @@ Error	C2757	'ofxSurfingHelpers': a symbol with this name already exists and ther
 //TODO: breaks bc recursive including?
 
 #include "imgui_styles.h"
-#include "surfingThemesHelpers.h"
+#include "./themes/SurfingThemesHelpers.h"
 
 //TODO: move here! now breaks!
 //#include "SurfingImGui/WindowFbo.h"
 //#include "SurfingImGui/WindowLog.h"
 
 #ifdef SURFING_IMGUI__USE_NOTIFIER
-	#include "SurfingImGui/notifiers/surfingNotifier.h"
+	#include "./notifiers/SurfingNotifier.h"
 #endif
 
 #ifdef SURFING_IMGUI__USE_PROFILE_DEBUGGER

--- a/src/SurfingImGui/themes/SurfingThemes.h
+++ b/src/SurfingImGui/themes/SurfingThemes.h
@@ -68,7 +68,7 @@ namespace ofxImGuiSurfing
 //macOS
 
 
-	auto mult = [](const ImVec4& vec, const float value) {
+	inline auto mult = [](const ImVec4& vec, const float value) {
 		return ImVec4{ vec.x * value, vec.y * value, vec.z * value, vec.w };
 	};
 


### PR DESCRIPTION
hey hey,
thanks for this addon. i am currently testing it.
had to fix some include paths, in order to compile it on linux (ubuntu 24.04, make and as a local addon). also i get duplicate symbol error with the mult function not being inline.

hope this does not break anything on other platforms.