### PR TITLE
fix for ofParameter<bool> single item constructor

### DIFF
--- a/src/SurfingImGui/SurfingGuiManager.cpp
+++ b/src/SurfingImGui/SurfingGuiManager.cpp
@@ -4624,28 +4624,28 @@ void SurfingGuiManager::keyPressed(ofKeyEventArgs & eventArgs) {
 		switch (key) {
 		case OF_KEY_F1:
 			bLayoutPresets[0] = !bLayoutPresets[0];
-			logKeyParamToggle(bLayoutPresets[0], "F1");
+				logKeyParamToggle(bLayoutPresets[0], {"F1", true});
 			doFlagBuildHelpInternalInfo();
 			return;
 			break;
 
 		case OF_KEY_F2:
 			bLayoutPresets[1] = !bLayoutPresets[1];
-			logKeyParamToggle(bLayoutPresets[1], "F2");
+				logKeyParamToggle(bLayoutPresets[1], {"F2", true});
 			doFlagBuildHelpInternalInfo();
 			return;
 			break;
 
 		case OF_KEY_F3:
 			bLayoutPresets[2] = !bLayoutPresets[2];
-			logKeyParamToggle(bLayoutPresets[2], "F3");
+				logKeyParamToggle(bLayoutPresets[2], {"F3", true});
 			doFlagBuildHelpInternalInfo();
 			return;
 			break;
 
 		case OF_KEY_F4:
 			bLayoutPresets[3] = !bLayoutPresets[3];
-			logKeyParamToggle(bLayoutPresets[3], "F4");
+				logKeyParamToggle(bLayoutPresets[3], {"F4", true});
 			doFlagBuildHelpInternalInfo();
 			return;
 			break;
@@ -4657,7 +4657,7 @@ void SurfingGuiManager::keyPressed(ofKeyEventArgs & eventArgs) {
 		if (key == OF_KEY_F5) // Presets
 		{
 			bGui_LayoutsPresetsSelector = !bGui_LayoutsPresetsSelector;
-			logKeyParamToggle(bGui_LayoutsPresetsSelector, "F5");
+			logKeyParamToggle(bGui_LayoutsPresetsSelector, {"F5", true});
 			doFlagBuildHelpInternalInfo();
 			return;
 		}
@@ -4665,7 +4665,7 @@ void SurfingGuiManager::keyPressed(ofKeyEventArgs & eventArgs) {
 		else if (key == OF_KEY_F6) // Panels
 		{
 			bGui_LayoutsPanels = !bGui_LayoutsPanels;
-			logKeyParamToggle(bGui_LayoutsPanels, "F6");
+			logKeyParamToggle(bGui_LayoutsPanels, {"F6", true});
 			doFlagBuildHelpInternalInfo();
 			return;
 		}
@@ -4673,7 +4673,7 @@ void SurfingGuiManager::keyPressed(ofKeyEventArgs & eventArgs) {
 		else if (key == OF_KEY_F7) // Manager
 		{
 			bGui_LayoutsManager = !bGui_LayoutsManager;
-			logKeyParamToggle(bGui_LayoutsManager, "F7");
+			logKeyParamToggle(bGui_LayoutsManager, {"F7", true});
 			doFlagBuildHelpInternalInfo();
 			return;
 		}
@@ -4825,7 +4825,7 @@ void SurfingGuiManager::keyPressed(ofKeyEventArgs & eventArgs) {
 	// Solo
 	if ((key == 's' && bMod_CONTROL) || key == 19) {
 		bSolo = !bSolo;
-		logKeyParamToggle(bSolo, "Ctrl + s");
+		logKeyParamToggle(bSolo, {"Ctrl + s", true});
 		doFlagBuildHelpInternalInfo();
 		return;
 	}

--- a/src/SurfingImGui/SurfingGuiManager.h
+++ b/src/SurfingImGui/SurfingGuiManager.h
@@ -4505,7 +4505,7 @@ private:
 
 	//-
 
-	vector<ofParameter<bool>> bLayoutPresets { "bLayoutPresets" }; // each window show toggles
+	vector<ofParameter<bool>> bLayoutPresets {  }; // each window show toggles
 	void Changed_Params(ofAbstractParameter & e);
 	ofParameterGroup params_LayoutsPanel { "Layouts Panel" };
 


### PR DESCRIPTION
prior to OF12.1 this is accepted:
```c++
ofParameter<bool> b {"bool"};
```
however thanks to implict conversion it means something which is not probably expected:
```c++
ofParameter<bool> b {true}; // the char* is converted to true.
```

https://github.com/openframeworks/openFrameworks/pull/8132 introduces a template restriction preventing the mistake to occur, forcing correct use of either a bool (or numeric) type as a single argument for the bool parameters. in order to initialize with a name, 2 arguments are now required (string, bool).
